### PR TITLE
Fix mediafiles

### DIFF
--- a/infra/nginx/vhost.d/default
+++ b/infra/nginx/vhost.d/default
@@ -1,3 +1,7 @@
 location /static {
     alias /usr/share/nginx/static;
 }
+
+location /media {
+    alias /usr/share/nginx/media;
+}

--- a/infra/server/start_nginx_acme.sh
+++ b/infra/server/start_nginx_acme.sh
@@ -14,8 +14,8 @@ docker run --detach \
   --volume html:/usr/share/nginx/html \
   --volume /var/run/docker.sock:/tmp/docker.sock:ro \
   --volume ./infra/nginx/conf.d/custom_proxy.conf:/etc/nginx/conf.d/custom_proxy.conf \
-  --volume ./infra/nginx/conf.d/fallback_server.conf:/etc/nginx/conf.d/fallback_server.conf \
   --volume staticfiles:/usr/share/nginx/static \
+  --volume mediafiles:/usr/share/nginx/media \
   --volume ./infra/nginx/vhost.d/default:/etc/nginx/vhost.d/default \
   --network shared \
   nginxproxy/nginx-proxy

--- a/src/app/validators/br/doc.py
+++ b/src/app/validators/br/doc.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
+from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
 from validate_docbr import (
     CNH,
@@ -17,7 +18,7 @@ from validate_docbr import (
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
-
+@deconstructible
 class BrazilianDocBaseValidator:
     message: "StrOrPromise"
     validator: BaseDoc

--- a/src/app/validators/br/doc.py
+++ b/src/app/validators/br/doc.py
@@ -18,6 +18,7 @@ from validate_docbr import (
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
+
 @deconstructible
 class BrazilianDocBaseValidator:
     message: "StrOrPromise"

--- a/staging.yml
+++ b/staging.yml
@@ -11,6 +11,7 @@ services:
       dockerfile: infra/app/Dockerfile
     volumes:
       - staticfiles:/app/storage/static
+      - mediafiles:/app/storage/media
       - translations:/app/locale
     ports:
       - 80
@@ -46,6 +47,9 @@ volumes:
     external: true
     name: staticfiles
   translations:
+  mediafiles:
+    external: true
+    name: mediafiles
 
 networks:
   shared:


### PR DESCRIPTION
Added external flag to mediafiles in staging
Added volume to mediafiles and removed volume to nonexistent file in nginx

Added deconstructible decorator to brazilian doc validators, so they can now be serialized by migrations